### PR TITLE
Refactor vertical align helper classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+### Unreleased
+* backwards incompatible changes
+  * Change prefix in vertical align helper classes. `.text-top`, `.text-middle`
+    and `.text-bottom` are renamed to `.valign-top`, `.valign-middle`,
+    `.valign-bottom`. The rules are moved from `_type.scss` to `_utilities.scss`
+    partial and are included in main `_bootstrap-bookingsync.scss` stylesheet.

--- a/assets/stylesheets/_bootstrap-bookingsync.scss
+++ b/assets/stylesheets/_bootstrap-bookingsync.scss
@@ -61,3 +61,4 @@
 @import "bookingsync/chosen";
 @import "bookingsync/switch";
 @import "bookingsync/smiles";
+@import "bookingsync/utilities";

--- a/assets/stylesheets/bookingsync/_type.scss
+++ b/assets/stylesheets/bookingsync/_type.scss
@@ -1,4 +1,0 @@
-// Vertical Alignment
-.text-top             { vertical-align: top; }
-.text-middle          { vertical-align: middle; }
-.text-bottom          { vertical-align: bottom; }

--- a/assets/stylesheets/bookingsync/_utilities.scss
+++ b/assets/stylesheets/bookingsync/_utilities.scss
@@ -1,0 +1,4 @@
+// Vertical Alignment
+.valign-top             { vertical-align: top; }
+.valign-middle          { vertical-align: middle; }
+.valign-bottom          { vertical-align: bottom; }


### PR DESCRIPTION
Change the prefix from .text- to more generic .valign- and put the
rules into _utilities.scss because they are not only related to
typography (e.g. vertical alignment in tables cells).

Different name won't suggest that they have similar effect as helpers
like .text-center only in vertical direction. It also won't be confusing
to use them for aligning block element inside table cells.

For more info check the discussion in
https://github.com/BookingSync/bootstrap-bookingsync-sass/commit/bb5ff4e